### PR TITLE
[feature] Response, Exception 추가

### DIFF
--- a/src/main/java/com/overcomingroom/bellbell/exception/CustomException.java
+++ b/src/main/java/com/overcomingroom/bellbell/exception/CustomException.java
@@ -1,0 +1,21 @@
+package com.overcomingroom.bellbell.exception;
+
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMsg());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomException{" +
+                "errorCode=" + errorCode +
+                '}';
+    }
+}

--- a/src/main/java/com/overcomingroom/bellbell/exception/ErrorCode.java
+++ b/src/main/java/com/overcomingroom/bellbell/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.overcomingroom.bellbell.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    // Weather
+    LOCATION_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "위치 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String msg;
+
+    ErrorCode(HttpStatus status, String msg) {
+        this.status = status;
+        this.msg = msg;
+    }
+
+}

--- a/src/main/java/com/overcomingroom/bellbell/exception/ErrorResponse.java
+++ b/src/main/java/com/overcomingroom/bellbell/exception/ErrorResponse.java
@@ -1,0 +1,26 @@
+package com.overcomingroom.bellbell.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+@Builder
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ErrorResponse {
+
+    private ErrorCode errorCode;
+    private String code;
+    private String message;
+    private HttpStatus httpStatus;
+
+    public ErrorResponse(ErrorCode errorCode) {
+        this.code = errorCode.getStatus().toString();
+        this.errorCode = errorCode;
+        this.httpStatus = errorCode.getStatus();
+        this.message = errorCode.getMsg();
+    }
+}

--- a/src/main/java/com/overcomingroom/bellbell/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/overcomingroom/bellbell/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package com.overcomingroom.bellbell.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<?> handlerCustomException(CustomException e) {
+        log.error("CustomException: " + e.getErrorCode().getMsg());
+        return new ResponseEntity<>(new ErrorResponse(e.getErrorCode()), e.getErrorCode().getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<?> handlerException(Exception e) {
+        log.error("Unexpected_Exception : " + e.getMessage());
+        return ResponseEntity.status(500).body("UNEXPECTED_EXCEPTION: " + e);
+    }
+}

--- a/src/main/java/com/overcomingroom/bellbell/response/ResResult.java
+++ b/src/main/java/com/overcomingroom/bellbell/response/ResResult.java
@@ -1,0 +1,29 @@
+package com.overcomingroom.bellbell.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 공통적으로 반환 될 속성
+ */
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ResResult<T> {
+
+    ResponseCode responseCode;
+    String code;
+    String message;
+    T data;
+
+    @Override
+    public String toString() {
+        return "ResResult{" +
+                "responseCode=" + responseCode +
+                ", code='" + code + '\'' +
+                ", message='" + message + '\'' +
+                ", data=" + data +
+                '}';
+    }
+}

--- a/src/main/java/com/overcomingroom/bellbell/response/ResponseCode.java
+++ b/src/main/java/com/overcomingroom/bellbell/response/ResponseCode.java
@@ -1,0 +1,33 @@
+package com.overcomingroom.bellbell.response;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@ToString
+public enum ResponseCode {
+
+    // Weather
+    LOCATION_INFORMATION_SEARCH_SUCCESSFUL(HttpStatus.OK, "200", "위치 정보 조회 성공");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ResponseCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    public ResponseEntity<ResResult> toResponse(Object data) {
+        return new ResponseEntity<>(ResResult.builder()
+                .responseCode(this)
+                .code(this.code)
+                .message(this.message)
+                .data(data)
+                .build(), httpStatus.OK);
+    }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #13 

## 📝 Description

- 응답 형태를 커스텀 했습니다.
- 에러 클래스를 생성 했습니다.

### 사용 예제

```
public ResponseEntity<ResResult> test(){
  ResponseCode responseCode = ResponseCode.TEST;
        return ResponseEntity.ok(ResResult.builder()
                .responseCode(responseCode)
                .code(responseCode.getCode())
                .message(responseCode.getMessage())
                .data(service.test( ))
                .build());
}
```

### 응답 결과
```
{
  "responseCode": "TEST",
  "code": "200",
  "message": "TEST 성공",
  "data": {
    "id": 1,
    "content": "ㅎㅇㅇ",
    "List": [
       "1", 
       "2"
    ]
  }
}
```