### PR TITLE
[Fix] login api 수정

### DIFF
--- a/src/main/java/com/overcomingroom/bellbell/config/SwaggerConfig.java
+++ b/src/main/java/com/overcomingroom/bellbell/config/SwaggerConfig.java
@@ -8,21 +8,21 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-        info = @Info(title = "bellbell",
-                description = "bellbell api - overcoming team",
-                version = "v1")
+    info = @Info(title = "bellbell",
+        description = "bellbell api - overcoming team",
+        version = "v1")
 )
 @RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
 
-    @Bean
-    public GroupedOpenApi snsOpenApi() {
-        String[] paths = {"/v1/**"};
+  @Bean
+  public GroupedOpenApi snsOpenApi() {
+    String[] paths = {"/v1/**"};
 
-        return GroupedOpenApi.builder()
-                .group("bellbell")
-                .pathsToMatch(paths)
-                .build();
-    }
+    return GroupedOpenApi.builder()
+        .group("bellbell")
+        .pathsToMatch(paths)
+        .build();
+  }
 }

--- a/src/main/java/com/overcomingroom/bellbell/exception/CustomException.java
+++ b/src/main/java/com/overcomingroom/bellbell/exception/CustomException.java
@@ -1,21 +1,22 @@
 package com.overcomingroom.bellbell.exception;
 
 public class CustomException extends RuntimeException {
-    private final ErrorCode errorCode;
 
-    public CustomException(ErrorCode errorCode) {
-        super(errorCode.getMsg());
-        this.errorCode = errorCode;
-    }
+  private final ErrorCode errorCode;
 
-    public ErrorCode getErrorCode() {
-        return errorCode;
-    }
+  public CustomException(ErrorCode errorCode) {
+    super(errorCode.getMsg());
+    this.errorCode = errorCode;
+  }
 
-    @Override
-    public String toString() {
-        return "CustomException{" +
-                "errorCode=" + errorCode +
-                '}';
-    }
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+
+  @Override
+  public String toString() {
+    return "CustomException{" +
+        "errorCode=" + errorCode +
+        '}';
+  }
 }

--- a/src/main/java/com/overcomingroom/bellbell/exception/ErrorCode.java
+++ b/src/main/java/com/overcomingroom/bellbell/exception/ErrorCode.java
@@ -5,19 +5,21 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ErrorCode {
+  // Member
+  MEMBER_INVALID(HttpStatus.BAD_REQUEST, "멤버 정보가 유효하지 않습니다."),
 
-    // OAuth
-    LOGIN_ERROR(HttpStatus.BAD_REQUEST, "로그인 오류"),
+  // OAuth
+  LOGIN_ERROR(HttpStatus.BAD_REQUEST, "로그인 오류"),
 
-    // Weather
-    LOCATION_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "위치 정보를 찾을 수 없습니다.");
+  // Weather
+  LOCATION_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "위치 정보를 찾을 수 없습니다.");
 
-    private final HttpStatus status;
-    private final String msg;
+  private final HttpStatus status;
+  private final String msg;
 
-    ErrorCode(HttpStatus status, String msg) {
-        this.status = status;
-        this.msg = msg;
-    }
+  ErrorCode(HttpStatus status, String msg) {
+    this.status = status;
+    this.msg = msg;
+  }
 
 }

--- a/src/main/java/com/overcomingroom/bellbell/exception/ErrorResponse.java
+++ b/src/main/java/com/overcomingroom/bellbell/exception/ErrorResponse.java
@@ -12,15 +12,15 @@ import org.springframework.http.HttpStatus;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorResponse {
 
-    private ErrorCode errorCode;
-    private String code;
-    private String message;
-    private HttpStatus httpStatus;
+  private ErrorCode errorCode;
+  private String code;
+  private String message;
+  private HttpStatus httpStatus;
 
-    public ErrorResponse(ErrorCode errorCode) {
-        this.code = errorCode.getStatus().toString();
-        this.errorCode = errorCode;
-        this.httpStatus = errorCode.getStatus();
-        this.message = errorCode.getMsg();
-    }
+  public ErrorResponse(ErrorCode errorCode) {
+    this.code = errorCode.getStatus().toString();
+    this.errorCode = errorCode;
+    this.httpStatus = errorCode.getStatus();
+    this.message = errorCode.getMsg();
+  }
 }

--- a/src/main/java/com/overcomingroom/bellbell/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/overcomingroom/bellbell/exception/GlobalExceptionHandler.java
@@ -10,15 +10,15 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @Slf4j
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    @ExceptionHandler(CustomException.class)
-    protected ResponseEntity<?> handlerCustomException(CustomException e) {
-        log.error("CustomException: " + e.getErrorCode().getMsg());
-        return new ResponseEntity<>(new ErrorResponse(e.getErrorCode()), e.getErrorCode().getStatus());
-    }
+  @ExceptionHandler(CustomException.class)
+  protected ResponseEntity<?> handlerCustomException(CustomException e) {
+    log.error("CustomException: " + e.getErrorCode().getMsg());
+    return new ResponseEntity<>(new ErrorResponse(e.getErrorCode()), e.getErrorCode().getStatus());
+  }
 
-    @ExceptionHandler(Exception.class)
-    protected ResponseEntity<?> handlerException(Exception e) {
-        log.error("Unexpected_Exception : " + e.getMessage());
-        return ResponseEntity.status(500).body("UNEXPECTED_EXCEPTION: " + e);
-    }
+  @ExceptionHandler(Exception.class)
+  protected ResponseEntity<?> handlerException(Exception e) {
+    log.error("Unexpected_Exception : " + e.getMessage());
+    return ResponseEntity.status(500).body("UNEXPECTED_EXCEPTION: " + e);
+  }
 }

--- a/src/main/java/com/overcomingroom/bellbell/member/domain/controller/MemberController.java
+++ b/src/main/java/com/overcomingroom/bellbell/member/domain/controller/MemberController.java
@@ -1,0 +1,40 @@
+package com.overcomingroom.bellbell.member.domain.controller;
+
+import com.overcomingroom.bellbell.member.domain.service.MemberService;
+import com.overcomingroom.bellbell.oauth.dto.ResponseToken;
+import com.overcomingroom.bellbell.response.ResResult;
+import com.overcomingroom.bellbell.response.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 멤버 관련 API 를 처리하는 컨트롤러입니다.
+ */
+@RestController
+@RequiredArgsConstructor
+public class MemberController {
+
+  private final MemberService memberService;
+
+  /**
+   * 멤버 정보를 반환하는 메서드입니다.
+   *
+   * @param accessToken 클라이언트를 통해 전달받은 액세스 토큰
+   * @return 멤버 정보
+   */
+  @PostMapping("/v1/member")
+  public ResponseEntity<ResResult> getUserInfo(@RequestBody ResponseToken accessToken) {
+    ResponseCode responseCode = ResponseCode.MEMBER_INFO_GET_SUCCESSFUL;
+    return ResponseEntity.ok(
+        ResResult.builder()
+            .responseCode(responseCode)
+            .code(responseCode.getCode())
+            .message(responseCode.getMessage())
+            .data(memberService.getMemberInfo(accessToken))
+            .build()
+    );
+  }
+}

--- a/src/main/java/com/overcomingroom/bellbell/member/domain/controller/MemberController.java
+++ b/src/main/java/com/overcomingroom/bellbell/member/domain/controller/MemberController.java
@@ -1,13 +1,12 @@
 package com.overcomingroom.bellbell.member.domain.controller;
 
 import com.overcomingroom.bellbell.member.domain.service.MemberService;
-import com.overcomingroom.bellbell.oauth.dto.ResponseToken;
 import com.overcomingroom.bellbell.response.ResResult;
 import com.overcomingroom.bellbell.response.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -25,8 +24,8 @@ public class MemberController {
    * @param accessToken 클라이언트를 통해 전달받은 액세스 토큰
    * @return 멤버 정보
    */
-  @PostMapping("/v1/member")
-  public ResponseEntity<ResResult> getUserInfo(@RequestBody ResponseToken accessToken) {
+  @GetMapping("/v1/member")
+  public ResponseEntity<ResResult> getUserInfo(@RequestHeader("Authorization") String accessToken) {
     ResponseCode responseCode = ResponseCode.MEMBER_INFO_GET_SUCCESSFUL;
     return ResponseEntity.ok(
         ResResult.builder()

--- a/src/main/java/com/overcomingroom/bellbell/member/domain/dto/KakaoUserInfo.java
+++ b/src/main/java/com/overcomingroom/bellbell/member/domain/dto/KakaoUserInfo.java
@@ -14,6 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class KakaoUserInfo {
+
   private String nickname; // 카카오 프로필 닉네임
   private String email; // 카카오 프로필 이메일
 

--- a/src/main/java/com/overcomingroom/bellbell/member/domain/entity/Member.java
+++ b/src/main/java/com/overcomingroom/bellbell/member/domain/entity/Member.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/src/main/java/com/overcomingroom/bellbell/member/domain/service/MemberService.java
+++ b/src/main/java/com/overcomingroom/bellbell/member/domain/service/MemberService.java
@@ -89,8 +89,8 @@ public class MemberService {
    * @param accessToken 클라이언트로부터 받아온 액세스 토큰
    * @return Member 정보가 저장된 DTO
    */
-  public KakaoUserInfo getMemberInfo(ResponseToken accessToken) {
-    Member member = loadMember(getKakaoUserInfo(accessToken)).orElseThrow(
+  public KakaoUserInfo getMemberInfo(String accessToken) {
+    Member member = loadMember(getKakaoUserInfo(new ResponseToken(accessToken))).orElseThrow(
         () -> new CustomException(ErrorCode.MEMBER_INVALID));
     return new KakaoUserInfo(member.getNickname(), member.getEmail());
   }

--- a/src/main/java/com/overcomingroom/bellbell/member/domain/service/MemberService.java
+++ b/src/main/java/com/overcomingroom/bellbell/member/domain/service/MemberService.java
@@ -5,33 +5,94 @@ import com.overcomingroom.bellbell.exception.ErrorCode;
 import com.overcomingroom.bellbell.member.domain.dto.KakaoUserInfo;
 import com.overcomingroom.bellbell.member.domain.entity.Member;
 import com.overcomingroom.bellbell.member.repository.MemberRepository;
+import com.overcomingroom.bellbell.oauth.dto.ResponseToken;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
+@Slf4j
 public class MemberService {
+
+  @Value("${spring.security.oauth2.client.provider.kakao.user-info-uri}")
+  private String userInfoUrl;
 
   private final MemberRepository memberRepository;
 
   /**
    * 카카오에서 받아온 사용자 정보로 회원을 불러옵니다.
+   *
    * @param kakaoUserInfo 카카오에서 받아온 사용자 정보
    * @return 불러온 회원 엔티티
    */
-  public Member loadKakaoUser(KakaoUserInfo kakaoUserInfo) {
-    return memberRepository.findByEmail(kakaoUserInfo.getEmail()).orElseThrow(() -> new CustomException(ErrorCode.LOGIN_ERROR));
+  public Optional<Member> loadMember(KakaoUserInfo kakaoUserInfo) {
+    return memberRepository.findByEmail(kakaoUserInfo.getEmail());
   }
 
   /**
    * 카카오에서 받아온 사용자 정보를 회원으로 저장합니다.
+   *
    * @param kakaoUserInfo 카카오에서 받아온 사용자 정보
    * @return 저장된 회원 엔티티
    */
-  public Member saveKakaoUser(KakaoUserInfo kakaoUserInfo) {
+  public Member saveMember(KakaoUserInfo kakaoUserInfo) {
     return memberRepository.save(kakaoUserInfo.toEntity());
+  }
+
+  /**
+   * 액세스 토큰으로 카카오에서 사용자정보를 받아옵니다.
+   *
+   * @param responseToken 클라이언트로부터 받아온 액세스 토큰
+   * @return 카카오 사용자 정보
+   */
+
+  public KakaoUserInfo getKakaoUserInfo(ResponseToken responseToken) {
+    log.info(responseToken.getAccessToken());
+    // 받은 액세스 토큰을 사용하여 사용자 정보 요청
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+    headers.setBearerAuth(responseToken.getAccessToken());
+    RequestEntity<?> requestEntity = RequestEntity.get(userInfoUrl).headers(headers).build();
+
+    // 사용자 정보 요청
+    RestTemplate restTemplate = new RestTemplate();
+    ResponseEntity<String> userInfoResponse = restTemplate.exchange(requestEntity, String.class);
+    String userInfo = userInfoResponse.getBody();
+
+    log.info("UserInfo: " + userInfo);
+
+    JSONObject userInfoData = new JSONObject(userInfoResponse.getBody());
+    String email = userInfoData.getJSONObject("kakao_account").get("email").toString();
+    String nickname = userInfoData.getJSONObject("properties").get("nickname").toString();
+    KakaoUserInfo kakaoUserInfo = new KakaoUserInfo(nickname, email);
+
+    log.info("email: {}", email);
+    log.info("nickname: {}", nickname);
+
+    return kakaoUserInfo;
+  }
+
+  /**
+   * 액세스 토큰으로 카카오에서 받아온 사용자정보를 통해 DB에 저장된 멤버 정보를 반환합니다.
+   *
+   * @param accessToken 클라이언트로부터 받아온 액세스 토큰
+   * @return Member 정보가 저장된 DTO
+   */
+  public KakaoUserInfo getMemberInfo(ResponseToken accessToken) {
+    Member member = loadMember(getKakaoUserInfo(accessToken)).orElseThrow(
+        () -> new CustomException(ErrorCode.MEMBER_INVALID));
+    return new KakaoUserInfo(member.getNickname(), member.getEmail());
   }
 
 }

--- a/src/main/java/com/overcomingroom/bellbell/oauth/controller/OAuthController.java
+++ b/src/main/java/com/overcomingroom/bellbell/oauth/controller/OAuthController.java
@@ -22,7 +22,7 @@ public class OAuthController {
    * 카카오 OAuth 콜백 처리 메서드입니다.
    *
    * @param code 카카오를 통해 클라이언트 측에서 전달받은 인가 코드
-   * @return 카카오로부터 받은 유저 정보의 응답
+   * @return 카카오로부터 받은 AccessToken
    */
   @GetMapping("/v1/login")
   public ResponseEntity<ResResult> loginWithKakao(@RequestParam String code) {

--- a/src/main/java/com/overcomingroom/bellbell/oauth/dto/ResponseToken.java
+++ b/src/main/java/com/overcomingroom/bellbell/oauth/dto/ResponseToken.java
@@ -1,0 +1,14 @@
+package com.overcomingroom.bellbell.oauth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseToken {
+
+  private String accessToken; // 카카오로 부터 응답 받은 AccessToken
+
+}

--- a/src/main/java/com/overcomingroom/bellbell/response/ResResult.java
+++ b/src/main/java/com/overcomingroom/bellbell/response/ResResult.java
@@ -12,18 +12,18 @@ import lombok.Getter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ResResult<T> {
 
-    ResponseCode responseCode;
-    String code;
-    String message;
-    T data;
+  ResponseCode responseCode;
+  String code;
+  String message;
+  T data;
 
-    @Override
-    public String toString() {
-        return "ResResult{" +
-                "responseCode=" + responseCode +
-                ", code='" + code + '\'' +
-                ", message='" + message + '\'' +
-                ", data=" + data +
-                '}';
-    }
+  @Override
+  public String toString() {
+    return "ResResult{" +
+        "responseCode=" + responseCode +
+        ", code='" + code + '\'' +
+        ", message='" + message + '\'' +
+        ", data=" + data +
+        '}';
+  }
 }

--- a/src/main/java/com/overcomingroom/bellbell/response/ResponseCode.java
+++ b/src/main/java/com/overcomingroom/bellbell/response/ResponseCode.java
@@ -8,29 +8,31 @@ import org.springframework.http.ResponseEntity;
 @Getter
 @ToString
 public enum ResponseCode {
+  // Member
+  MEMBER_INFO_GET_SUCCESSFUL(HttpStatus.OK, "200", "멤버 정보 조회 성공"),
 
-    // OAuth
-    LOGIN_SUCCESSFUL(HttpStatus.OK, "200", "로그인 성공"),
+  // OAuth
+  LOGIN_SUCCESSFUL(HttpStatus.OK, "200", "로그인 성공"),
 
-    // Weather
-    LOCATION_INFORMATION_SEARCH_SUCCESSFUL(HttpStatus.OK, "200", "위치 정보 조회 성공");
+  // Weather
+  LOCATION_INFORMATION_SEARCH_SUCCESSFUL(HttpStatus.OK, "200", "위치 정보 조회 성공");
 
-    private final HttpStatus httpStatus;
-    private final String code;
-    private final String message;
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
 
-    ResponseCode(HttpStatus httpStatus, String code, String message) {
-        this.httpStatus = httpStatus;
-        this.code = code;
-        this.message = message;
-    }
+  ResponseCode(HttpStatus httpStatus, String code, String message) {
+    this.httpStatus = httpStatus;
+    this.code = code;
+    this.message = message;
+  }
 
-    public ResponseEntity<ResResult> toResponse(Object data) {
-        return new ResponseEntity<>(ResResult.builder()
-                .responseCode(this)
-                .code(this.code)
-                .message(this.message)
-                .data(data)
-                .build(), httpStatus.OK);
-    }
+  public ResponseEntity<ResResult> toResponse(Object data) {
+    return new ResponseEntity<>(ResResult.builder()
+        .responseCode(this)
+        .code(this.code)
+        .message(this.message)
+        .data(data)
+        .build(), httpStatus.OK);
+  }
 }


### PR DESCRIPTION
## 📝 Description
- before: 카카오 유저 정보 반환
- after: login api 는 액세스 토큰만 반환, 사용자 정보 반환 api(/v1/member) 추가

## ⭐️ Review

기존 login api 에서 유저 정보를 반환하는 형태에서 액세스 토큰을 반환하는 형태로 변경하였습니다.
유저 정보를 반환하는 api를 생성하였습니다.
코드 컨벤션에 맞지 않는 공백을 수정하였습니다.
