### PR TITLE
[Fix] Swagger Authentication 방식으로 변경

### DIFF
--- a/src/main/java/com/overcomingroom/bellbell/config/SwaggerConfig.java
+++ b/src/main/java/com/overcomingroom/bellbell/config/SwaggerConfig.java
@@ -4,13 +4,9 @@ import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.Paths;
-import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.customizers.OpenApiCustomizer;
-import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/com/overcomingroom/bellbell/config/SwaggerConfig.java
+++ b/src/main/java/com/overcomingroom/bellbell/config/SwaggerConfig.java
@@ -2,7 +2,14 @@ package com.overcomingroom.bellbell.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,13 +23,18 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
-  @Bean
-  public GroupedOpenApi snsOpenApi() {
-    String[] paths = {"/v1/**"};
+  private SecurityScheme createAPIKeyScheme() {
+    return new SecurityScheme().type(SecurityScheme.Type.HTTP)
+        .bearerFormat("JWT")
+        .scheme("bearer");
+  }
 
-    return GroupedOpenApi.builder()
-        .group("bellbell")
-        .pathsToMatch(paths)
-        .build();
+  @Bean
+  public OpenAPI openApi() {
+    return new OpenAPI().addSecurityItem(new SecurityRequirement().
+            addList("Bearer Authentication"))
+        .components(new Components().addSecuritySchemes
+            ("Bearer Authentication", createAPIKeyScheme()));
   }
 }
+

--- a/src/main/java/com/overcomingroom/bellbell/member/domain/controller/MemberController.java
+++ b/src/main/java/com/overcomingroom/bellbell/member/domain/controller/MemberController.java
@@ -32,7 +32,7 @@ public class MemberController {
             .responseCode(responseCode)
             .code(responseCode.getCode())
             .message(responseCode.getMessage())
-            .data(memberService.getMemberInfo(accessToken))
+            .data(memberService.getMemberInfo(accessToken.substring(7)))
             .build()
     );
   }


### PR DESCRIPTION
## 📝 Description

`Swagger` 에 `Authentication` 설정을 추가하였습니다.
기존에 path를 기준으로 그룹화 되어 있던 설정을 삭제하였습니다. (추후에 필요시 추가하도록 합니다.) 

![image](https://github.com/OvercomingRoom/Bellbell/assets/87625236/613015c1-d514-4962-bf93-954ec27b0280)
`액세스 토큰` 을 입력하여 권한을 부여받고
![image](https://github.com/OvercomingRoom/Bellbell/assets/87625236/6b2ea9eb-fb08-4eb6-95f6-fef7ea735d8a)
`Bearer ` 입력 후 액세스 토큰을 입력하여 `Authorization` 헤더 설정 후 요청합니다.

