### PR TITLE
[Feature] 사용자 생성 알림 기능 구현

### DIFF
--- a/src/main/java/com/overcomingroom/bellbell/exception/ErrorCode.java
+++ b/src/main/java/com/overcomingroom/bellbell/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 
   // OAuth
   LOGIN_ERROR(HttpStatus.BAD_REQUEST, "로그인 오류"),
+  ACCESS_DENIED(HttpStatus.BAD_REQUEST, "접근 권한이 없습니다."),
 
   // Weather
   LOCATION_INFORMATION_NOT_FOUND(HttpStatus.NOT_FOUND, "위치 정보를 찾을 수 없습니다."),
@@ -19,7 +20,11 @@ public enum ErrorCode {
   SI_API_CALL_BAD_REQUEST(HttpStatus.BAD_REQUEST, "알맞는 시, 도를 입력해 주세요. ex) 서울특별시, 경상남도.."),
   GU_API_CALL_BAD_REQUEST(HttpStatus.BAD_REQUEST, "알맞는 시, 구, 군을 입력해 주세요. ex)종로구, 사상구, 창원시.."),
   DONG_API_CALL_BAD_REQUEST(HttpStatus.BAD_REQUEST, "알맞는 동, 읍, 면, 리를 입력해 주세요. ex) 종로1가, 괘법동..."),
-  WEATHER_API_RES_RESULT_IS_EMPTY(HttpStatus.NOT_FOUND, "날씨 데이터가 존재하지 않습니다.");
+  WEATHER_API_RES_RESULT_IS_EMPTY(HttpStatus.NOT_FOUND, "날씨 데이터가 존재하지 않습니다."),
+
+  // UserNotification
+  INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),
+  NOT_EXISTS_USER_NOTIFICATION(HttpStatus.BAD_REQUEST, "사용자 알림이 존재하지 않습니다.");
 
   private final HttpStatus status;
   private final String msg;

--- a/src/main/java/com/overcomingroom/bellbell/member/domain/entity/Member.java
+++ b/src/main/java/com/overcomingroom/bellbell/member/domain/entity/Member.java
@@ -1,10 +1,16 @@
 package com.overcomingroom.bellbell.member.domain.entity;
 
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.overcomingroom.bellbell.usernotification.domain.entity.UserNotification;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,6 +26,7 @@ public class Member {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "member_id")
   private Long id;
 
   // 닉네임
@@ -30,10 +37,15 @@ public class Member {
   @Column(nullable = false)
   private String email;
 
+  // 사용자 생성 알림 (1:N)
+  @OneToMany(fetch = LAZY, mappedBy = "member", orphanRemoval = true)
+  private List<UserNotification> userNotifications = new ArrayList<>();
+
   @Builder
-  public Member(String nickname, String email) {
+  public Member(String nickname, String email, List<UserNotification> userNotifications) {
     this.nickname = nickname;
     this.email = email;
+    this.userNotifications = userNotifications;
   }
 
 }

--- a/src/main/java/com/overcomingroom/bellbell/member/domain/service/MemberService.java
+++ b/src/main/java/com/overcomingroom/bellbell/member/domain/service/MemberService.java
@@ -94,6 +94,11 @@ public class MemberService {
     return new KakaoUserInfo(member.getNickname(), member.getEmail());
   }
 
+  public Member getMember(String accessToken) {
+    return memberRepository.findByEmail(getMemberInfo(accessToken).getEmail())
+        .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_INVALID));
+  }
+
   public List<Member> getAllMembers() {
     return memberRepository.findAll();
   }

--- a/src/main/java/com/overcomingroom/bellbell/response/ResponseCode.java
+++ b/src/main/java/com/overcomingroom/bellbell/response/ResponseCode.java
@@ -17,7 +17,12 @@ public enum ResponseCode {
   // Weather
   LOCATION_INFORMATION_SEARCH_SUCCESSFUL(HttpStatus.OK, "200", "위치 정보 조회 성공"),
   WEATHER_INFO_GET_SUCCESSFUL(HttpStatus.OK, "200" ,"날씨 정보 조회 성공" ),
-  MEMBER_LOCATION_SAVE_SUCCESSFUL(HttpStatus.OK, "200" ,"위치 정보 저장 성공" );
+  MEMBER_LOCATION_SAVE_SUCCESSFUL(HttpStatus.OK, "200" ,"위치 정보 저장 성공" ),
+
+  // UserNotification
+  USER_NOTIFICATION_CREATE_SUCCESSFUL(HttpStatus.OK, "200", "사용자 알림 생성 성공"),
+  USER_NOTIFICATIONS_GET_SUCCESSFUL(HttpStatus.OK, "200", "사용자 알림 목록 가져오기 성공"),
+  USER_NOTIFICATION_DELETE_SUCCESSFUL(HttpStatus.OK, "200", "사용자 알림 삭제 성공");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/src/main/java/com/overcomingroom/bellbell/usernotification/controller/UserNotificationController.java
+++ b/src/main/java/com/overcomingroom/bellbell/usernotification/controller/UserNotificationController.java
@@ -1,0 +1,88 @@
+package com.overcomingroom.bellbell.usernotification.controller;
+
+import com.overcomingroom.bellbell.response.ResResult;
+import com.overcomingroom.bellbell.response.ResponseCode;
+import com.overcomingroom.bellbell.usernotification.domain.dto.UserNotificationRequestDto;
+import com.overcomingroom.bellbell.usernotification.service.UserNotificationService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/notifications")
+public class UserNotificationController {
+
+  private final UserNotificationService userNotificationService;
+
+  /**
+   * 사용자 알림 생성 요청을 처리합니다.
+   *
+   * @param accessToken 사용자의 액세스 토큰
+   * @param dto         요청 데이터 전송 객체
+   * @return ResponseEntity 객체
+   */
+  @PostMapping("/create")
+  public ResponseEntity<ResResult> createUserNotification(
+      @RequestHeader("Authorization") String accessToken,
+      final @RequestBody @Valid UserNotificationRequestDto dto) {
+    ResponseCode responseCode = userNotificationService.createUserNotification(
+        accessToken.substring(7), dto);
+    return ResponseEntity.ok(
+        ResResult.builder()
+            .responseCode(responseCode)
+            .code(responseCode.getCode())
+            .message(responseCode.getMessage())
+            .build()
+    );
+  }
+
+  /**
+   * 사용자의 알림 목록을 반환합니다.
+   *
+   * @param accessToken 사용자의 액세스 토큰
+   * @return ResponseEntity 객체
+   */
+  @GetMapping
+  public ResponseEntity<ResResult> getUserNotifications(
+      @RequestHeader("Authorization") String accessToken) {
+    ResponseCode responseCode = ResponseCode.USER_NOTIFICATIONS_GET_SUCCESSFUL;
+    return ResponseEntity.ok(
+        ResResult.builder()
+            .responseCode(responseCode)
+            .code(responseCode.getCode())
+            .message(responseCode.getMessage())
+            .data(userNotificationService.getUserNotifications(accessToken.substring(7)))
+            .build()
+    );
+  }
+
+  /**
+   * 사용자의 특정 알림을 삭제합니다.
+   *
+   * @param accessToken   사용자의 액세스 토큰
+   * @param notificationId 삭제할 알림의 ID
+   * @return ResponseEntity 객체
+   */
+  @DeleteMapping("/delete/{notificationId}")
+  public ResponseEntity<ResResult> deleteUserNotification(
+      @RequestHeader("Authorization") String accessToken, @PathVariable Long notificationId) {
+    ResponseCode responseCode = userNotificationService.deleteUserNotification(
+        accessToken.substring(7), notificationId);
+    return ResponseEntity.ok(
+        ResResult.builder()
+            .responseCode(responseCode)
+            .code(responseCode.getCode())
+            .message(responseCode.getMessage())
+            .build()
+    );
+  }
+}

--- a/src/main/java/com/overcomingroom/bellbell/usernotification/domain/dto/UserNotificationRequestDto.java
+++ b/src/main/java/com/overcomingroom/bellbell/usernotification/domain/dto/UserNotificationRequestDto.java
@@ -1,0 +1,29 @@
+package com.overcomingroom.bellbell.usernotification.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+/**
+ * 사용자 알림 생성 요청을 위한 데이터 전송 객체입니다.
+ */
+@Getter
+public class UserNotificationRequestDto {
+
+  /**
+   * 알림 내용을 나타냅니다.
+   */
+  @NotBlank(message = "알림 내용은 필수 입력값입니다.")
+  private String content;
+
+  /**
+   * 알림 요일을 나타냅니다.
+   */
+  @NotBlank(message = "알림 요일은 필수 입력값입니다.")
+  private String day;
+
+  /**
+   * 알림 시간을 나타냅니다.
+   */
+  @NotBlank(message = "알림 시간은 필수 입력값입니다.")
+  private String time;
+}

--- a/src/main/java/com/overcomingroom/bellbell/usernotification/domain/dto/UserNotificationResponseDto.java
+++ b/src/main/java/com/overcomingroom/bellbell/usernotification/domain/dto/UserNotificationResponseDto.java
@@ -1,0 +1,31 @@
+package com.overcomingroom.bellbell.usernotification.domain.dto;
+
+import lombok.Data;
+
+/**
+ * 사용자 알림 조회 응답을 위한 데이터 전송 객체입니다.
+ */
+@Data
+public class UserNotificationResponseDto {
+
+  /**
+   * 알림의 고유 식별자를 나타냅니다.
+   */
+  private Long id;
+
+  /**
+   * 알림 내용을 나타냅니다.
+   */
+  private String content;
+
+  /**
+   * 알림 요일을 나타냅니다.
+   */
+  private String day;
+
+  /**
+   * 알림 시간을 나타냅니다.
+   */
+  private String time;
+
+}

--- a/src/main/java/com/overcomingroom/bellbell/usernotification/domain/entity/UserNotification.java
+++ b/src/main/java/com/overcomingroom/bellbell/usernotification/domain/entity/UserNotification.java
@@ -1,0 +1,51 @@
+package com.overcomingroom.bellbell.usernotification.domain.entity;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.overcomingroom.bellbell.member.domain.entity.Member;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserNotification {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "user_notification_id")
+  private Long id;
+
+  @Column(nullable = false)
+  private String content;
+
+  @Column(nullable = false)
+  private String time;
+
+  @Column(nullable = false)
+  private String day;
+
+  // 회원 (N:1)
+  @ManyToOne(fetch = LAZY, cascade = CascadeType.PERSIST)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @Builder
+  public UserNotification(String content, String time, String day, Member member) {
+    this.content = content;
+    this.time = time;
+    this.day = day;
+    this.member = member;
+  }
+
+}

--- a/src/main/java/com/overcomingroom/bellbell/usernotification/repository/UserNotificationRepository.java
+++ b/src/main/java/com/overcomingroom/bellbell/usernotification/repository/UserNotificationRepository.java
@@ -1,0 +1,13 @@
+package com.overcomingroom.bellbell.usernotification.repository;
+
+import com.overcomingroom.bellbell.member.domain.entity.Member;
+import com.overcomingroom.bellbell.usernotification.domain.entity.UserNotification;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserNotificationRepository extends JpaRepository<UserNotification, Long> {
+
+  Optional<List<UserNotification>> findAllByMember(Member member);
+
+}

--- a/src/main/java/com/overcomingroom/bellbell/usernotification/service/UserNotificationService.java
+++ b/src/main/java/com/overcomingroom/bellbell/usernotification/service/UserNotificationService.java
@@ -1,0 +1,87 @@
+package com.overcomingroom.bellbell.usernotification.service;
+
+import com.overcomingroom.bellbell.exception.CustomException;
+import com.overcomingroom.bellbell.exception.ErrorCode;
+import com.overcomingroom.bellbell.member.domain.entity.Member;
+import com.overcomingroom.bellbell.member.domain.service.MemberService;
+import com.overcomingroom.bellbell.response.ResponseCode;
+import com.overcomingroom.bellbell.usernotification.domain.dto.UserNotificationRequestDto;
+import com.overcomingroom.bellbell.usernotification.domain.dto.UserNotificationResponseDto;
+import com.overcomingroom.bellbell.usernotification.domain.entity.UserNotification;
+import com.overcomingroom.bellbell.usernotification.repository.UserNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 사용자 알림 서비스를 제공하는 클래스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class UserNotificationService {
+
+  private final UserNotificationRepository userNotificationRepository;
+  private final MemberService memberService;
+
+  /**
+   * 사용자 알림을 생성하는 메서드입니다.
+   *
+   * @param accessToken 사용자의 액세스 토큰
+   * @param dto         알림 생성 요청 DTO
+   * @return 응답 코드
+   */
+  public ResponseCode createUserNotification(String accessToken, UserNotificationRequestDto dto) {
+    Member member = memberService.getMember(accessToken);
+    userNotificationRepository.save(
+        new UserNotification(dto.getContent(), dto.getTime(), dto.getDay(), member));
+
+    return ResponseCode.USER_NOTIFICATION_CREATE_SUCCESSFUL;
+  }
+
+  /**
+   * 사용자의 모든 알림을 가져오는 메서드입니다.
+   *
+   * @param accessToken 사용자의 액세스 토큰
+   * @return 사용자 알림 목록 DTO
+   */
+  public List<UserNotificationResponseDto> getUserNotifications(String accessToken) {
+    Member member = memberService.getMember(accessToken);
+    List<UserNotification> userNotifications = userNotificationRepository.findAllByMember(member)
+        .orElseThrow(() -> new CustomException(
+            ErrorCode.NOT_EXISTS_USER_NOTIFICATION));
+    List<UserNotificationResponseDto> userNotificationResponseDtos = new ArrayList<>();
+    for (UserNotification userNotification : userNotifications) {
+      UserNotificationResponseDto dto = new UserNotificationResponseDto();
+      dto.setId(userNotification.getId());
+      dto.setContent(userNotification.getContent());
+      dto.setTime(userNotification.getTime());
+      dto.setDay(userNotification.getDay());
+      userNotificationResponseDtos.add(dto);
+    }
+    return userNotificationResponseDtos;
+  }
+
+  /**
+   * 사용자의 특정 알림을 삭제하는 메서드입니다.
+   *
+   * @param accessToken    사용자의 액세스 토큰
+   * @param notificationId 삭제할 알림의 ID
+   * @return 응답 코드
+   */
+  public ResponseCode deleteUserNotification(String accessToken, Long notificationId) {
+    Member member = memberService.getMember(accessToken);
+    UserNotification userNotification = userNotificationRepository.findById(notificationId)
+        .orElseThrow(() -> new CustomException(ErrorCode.NOT_EXISTS_USER_NOTIFICATION));
+    if (!userNotification.getMember().equals(member)) {
+      throw new CustomException(ErrorCode.ACCESS_DENIED);
+    }
+    userNotificationRepository.delete(userNotification);
+    return ResponseCode.USER_NOTIFICATION_DELETE_SUCCESSFUL;
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,7 +4,7 @@ spring:
     include: secret
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
       jdbc:
         batch_size=50
     properties:
@@ -16,7 +16,6 @@ spring:
 logging:
   level:
     root: INFO
-    com.wanted.sns_feed_service: DEBUG
     org.hibernate.orm.jdbc.bind: TRACE
     org.hibernate.orm.jdbc.extract: TRACE
 


### PR DESCRIPTION
## 🔥 Related Issue

close: #19 

## 📝 Description
사용자가 원하는 내용의 알림을 생성할 수 있는 기능을 구현하였습니다.
![image](https://github.com/OvercomingRoom/Bellbell/assets/87625236/13c0dbdd-c370-4bb2-80c0-157c65d83d6f)
![image](https://github.com/OvercomingRoom/Bellbell/assets/87625236/b9d778b6-cc5d-48d1-8ecc-9e555e4d3970)
![image](https://github.com/OvercomingRoom/Bellbell/assets/87625236/aec2b7b2-b9f8-4d02-9982-cddf21436633)
알림 요일은 `,` 로 구분하여 공백 없이 String 형식으로 저장합니다.(ex. `"MON,TUE,WED"`)
알림 수정 기능은 필요 시 추후에 추가하도록 하겠습니다.

## ⭐️ Review
프론트와 같이 작업하려니 생각보다 시간이 오래 걸렸습니다.
다음으로는 동적 스케줄러를 구현해 알림 메시지를 보내는 것 까지 구현하도록 하겠습니다.